### PR TITLE
Fix the submodule to use relative path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "als_driver"]
 	path = als_driver
-	url = git@github.com:danieleds/als.git
+	url = ../als.git


### PR DESCRIPTION
Use relative paths to refer to submodules. This guarantees that the submodule is fetched using the same protocol as the main repository, therefore fixing the issue when unauthenticated users were unable to
checkout the submodule because of it being fixed to authenticated SSH URI.
